### PR TITLE
Add ANN by Hamming distance using bit sampling LSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,24 @@ Spark itself doesn't yet support locality-sensitive hashing or nearest neighbor 
 
 ### Features
 - Batch computation of the nearest neighbors for each point in a dataset
+- Hamming distance via bit sampling LSH
 - Cosine distance via sign-random-projection LSH
 - Euclidean distance via scalar-random-projection LSH
 - Jaccard distance via Minhash LSH
 
 ### Usage
+
+Hamming distance:
+
+```scala
+val ann =
+  new ANN(dimensions, "hamming")
+    .setTables(4)
+    .setSignatureLength(64)
+
+val model = ann.train(vectors)
+val neighbors = model.neighbors(10)
+```
 
 Cosine distance:
 

--- a/src/main/scala/io/github/karlhigley/neighbors/linalg/DistanceMeasure.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/linalg/DistanceMeasure.scala
@@ -47,6 +47,20 @@ private[neighbors] final object EuclideanDistance extends DistanceMeasure {
   }
 }
 
+private[neighbors] final object HammingDistance extends DistanceMeasure {
+
+  /**
+   * Compute Hamming distance between vectors
+   *
+   * Since MLlib doesn't support binary vectors, this uses
+   * sparse vectors and considers any active (i.e. non-zero)
+   * index to represent a set bit
+   */
+  def compute(v1: SparseVector, v2: SparseVector): Double = {
+    v1.indices.intersect(v2.indices).size.toDouble
+  }
+}
+
 private[neighbors] final object JaccardDistance extends DistanceMeasure {
 
   /**

--- a/src/main/scala/io/github/karlhigley/neighbors/lsh/BitSamplingFunction.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/lsh/BitSamplingFunction.scala
@@ -1,0 +1,57 @@
+package io.github.karlhigley.neighbors.lsh
+
+import java.util.Random
+import scala.collection.immutable.BitSet
+
+import org.apache.spark.mllib.linalg.SparseVector
+
+/**
+ *
+ * References:
+ *  - Gionis, Indyk, Motwanit. "Similarity Search in High Dimensions via Hashing."
+ *    Very Large Data Bases, 1999.
+ *
+ * @see [[https://en.wikipedia.org/wiki/Locality-sensitive_hashing#Bit_sampling_for_Hamming_distance
+ *          Bit sampling for Hamming Distance (Wikipedia)]]
+ */
+private[neighbors] class BitSamplingFunction(
+    private[this] val sampledBits: Array[Int]
+) extends LSHFunction[BitSignature] with Serializable {
+
+  /**
+   * Compute the hash signature of the supplied vector
+   */
+  def signature(vector: SparseVector): BitSignature = {
+    val sampled = vector.indices.intersect(sampledBits)
+    new BitSignature(BitSet(sampled: _*))
+  }
+
+  /**
+   * Build a hash table entry for the supplied vector
+   */
+  def hashTableEntry(id: Int, table: Int, v: SparseVector): BitHashTableEntry = {
+    BitHashTableEntry(id, table, signature(v))
+  }
+}
+
+private[neighbors] object BitSamplingFunction {
+  /**
+   * Build a random hash function, given the vector dimension
+   * and signature length
+   *
+   * @param originalDim dimensionality of the vectors to be hashed
+   * @param signatureLength the number of bits in each hash signature
+   * @return randomly selected hash function from bit sampling family
+   */
+  def generate(
+    originalDim: Int,
+    signatureLength: Int,
+    random: Random = new Random
+  ): BitSamplingFunction = {
+    val indices = Array.fill(signatureLength) {
+      random.nextInt(originalDim)
+    }
+
+    new BitSamplingFunction(indices)
+  }
+}

--- a/src/test/scala/io/github/karlhigley/neighbors/ANNSuite.scala
+++ b/src/test/scala/io/github/karlhigley/neighbors/ANNSuite.scala
@@ -16,6 +16,23 @@ class ANNSuite extends FunSuite with TestSparkContext {
 
   val localVectors = generateRandomVectors(numVectors, dimensions, density)
 
+  test("compute hamming nearest neighbors as a batch") {
+    val vectors = sc.parallelize(localVectors.zipWithIndex.map(_.swap))
+
+    val ann =
+      new ANN(dimensions, "hamming")
+        .setTables(1)
+        .setSignatureLength(16)
+
+    val model = ann.train(vectors)
+    val neighbors = model.neighbors(10)
+
+    val localHashTables = model.hashTables.collect()
+    val localNeighbors = neighbors.collect()
+
+    runAssertions(localHashTables, localNeighbors)
+  }
+
   test("compute cosine nearest neighbors as a batch") {
     val vectors = sc.parallelize(localVectors.zipWithIndex.map(_.swap))
 


### PR DESCRIPTION
This also makes Hamming distance the default distance measure, since it's less expensive to compute than cosine distance.
