### PR TITLE
Avoid computing same distance twice by adjusting strategies & computation

### DIFF
--- a/src/main/scala/io/github/karlhigley/neighbors/ANNModel.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/ANNModel.scala
@@ -45,10 +45,10 @@ class ANNModel private[neighbors] (
         case (id1, (id2, vector1)) => (id2, (id1, vector1))
       }
       .join(vectors)
-      .map {
+      .flatMap {
         case (id2, ((id1, vector1), vector2)) =>
           val distance = measure.compute(vector1, vector2)
-          (id1, (id2, distance))
+          Array((id1, (id2, distance)), (id2, (id1, distance)))
       }
   }
 }

--- a/src/main/scala/io/github/karlhigley/neighbors/candidates/BandingCandidateStrategy.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/candidates/BandingCandidateStrategy.scala
@@ -41,7 +41,7 @@ private[neighbors] class BandingCandidateStrategy(
 
     bandEntries.persist(persistenceLevel)
     bandEntries.join(bandEntries).flatMap {
-      case (_, (id1, id2)) if (id1 != id2) => Some((id1, id2))
+      case (_, (id1, id2)) if (id1 < id2) => Some((id1, id2))
       case _ => None
     }
   }

--- a/src/main/scala/io/github/karlhigley/neighbors/candidates/SimpleCandidateStrategy.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/candidates/SimpleCandidateStrategy.scala
@@ -34,7 +34,7 @@ private[neighbors] class SimpleCandidateStrategy(
 
     entries.persist(persistenceLevel)
     entries.join(entries).flatMap {
-      case ((table, signature), (id1, id2)) if (id1 != id2) => Some((id1, id2))
+      case (_, (id1, id2)) if (id1 < id2) => Some((id1, id2))
       case _ => None
     }
   }


### PR DESCRIPTION
When a pair RDD contains (k, v1) and (k, v2), the result of a self-join includes
both (k, (v1, v2)) and (k, (v2, v1)).

In candidate strategies, the keys are (table #, signature) tuples and the values
are point ids, which leads to each pair of point ids being generated twice (in
opposite order), and therefore to the distance between any two points being
computed twice.

By adjusting the strategies to only emit pairs where id1 < id2, the distance can
be computed once for each candidate pair and the distance computation can emit
two records, containing the same distance with the ids swapped.
