### PR TITLE
Fix duplicate candidate pairs generated from multiple hash tables

### DIFF
--- a/src/main/scala/io/github/karlhigley/neighbors/ANNModel.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/ANNModel.scala
@@ -28,7 +28,7 @@ class ANNModel private[neighbors] (
    * the actual distance between candidate pairs.
    */
   def neighbors(quantity: Int): RDD[(Int, Array[(Int, Double)])] = {
-    val candidates = candidateStrategy.identify(hashTables)
+    val candidates = candidateStrategy.identify(hashTables).distinct()
     val neighbors = computeDistances(candidates)
     neighbors.topByKey(quantity)(ANNModel.ordering)
   }


### PR DESCRIPTION
It's possible that the same pair will match in multiple hash tables, but each
candidate pair should only be evaluated once. This adds a test for the removal
of duplicate neighbors, and filters them out via RDD.distinct() on the candidate
pairs before computing the actual distances.
