### PR TITLE
Cache candidate pairs rather than points

### DIFF
--- a/src/main/scala/io/github/karlhigley/neighbors/ANNModel.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/ANNModel.scala
@@ -38,7 +38,7 @@ class ANNModel private[neighbors] (
    * using the supplied distance measure.
    */
   private def computeDistances(candidates: RDD[(Int, Int)]): RDD[(Int, (Int, Double))] = {
-    points.persist(persistenceLevel)
+    candidates.persist(persistenceLevel)
     candidates
       .join(points)
       .map {


### PR DESCRIPTION
The points may already be cached with a different persistence level, which can't
be changed once set. It still helps to cache the candidate pairs, though.
