### PR TITLE
Configure as a Spark package using sbt-spark-package plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,22 +1,24 @@
-name := "spark-neighbors"
+lazy val root = (project in file(".")).
+  settings(
+    spName := "io.github.karlhigley/spark-neighbors",
+    version := "0.1.0",
+    scalaVersion := "2.10.5",
+    sparkVersion := "1.6.0",
+    sparkComponents += "mllib",
 
-organization := "io.github.karlhigley"
-
-version := "0.0.1"
-
-scalaVersion := "2.10.5"
+    spShortDescription := "Approximate nearest neighbor search using locality-sensitive hashing",
+	spDescription := """Batch computation of the nearest neighbors for each point in a dataset using:
+	                    | - Hamming distance via bit sampling LSH
+	                    | - Cosine distance via sign-random-projection LSH
+	                    | - Euclidean distance via scalar-random-projection LSH
+	                    | - Jaccard distance via Minhash LSH""".stripMargin
+  )
 
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core" % "1.6.0" % "provided",
-  "org.apache.spark" %% "spark-mllib" % "1.6.0" % "provided",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "com.typesafe.akka" %% "akka-actor" % "2.3.4" % "test"
 )
 
-resolvers ++= Seq(
-  "Akka Repository" at "http://repo.akka.io/releases/",
-  "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
-  "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/"
-)
-
 parallelExecution in Test := false
+
+credentials += Credentials(Path.userHome / ".ivy2" / ".spark-package-credentials")

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
-resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
+
+addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.3")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 


### PR DESCRIPTION
The Spark package plugin provides better ways to specify many settings and
results in a generally cleaner build file. (The plugin includes sbt-assembly, so
that no longer needs to be added explicitly.)
