### PR TITLE
Fix organization name for Spark package

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = (project in file(".")).
   settings(
-    spName := "io.github.karlhigley/spark-neighbors",
+    spName := "karlhigley/spark-neighbors",
     version := "0.1.0",
     scalaVersion := "2.10.5",
     sparkVersion := "1.6.0",


### PR DESCRIPTION
It wants the Github organization (i.e. me), not the namespace organization.
(Package successfully submitted to the Spark Packages index following this
change.)
