### PR TITLE
Revert sbt-spark-package commits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,22 @@
-lazy val root = (project in file(".")).
-  settings(
-    spName := "karlhigley/spark-neighbors",
-    version := "0.1.0",
-    scalaVersion := "2.10.5",
-    sparkVersion := "1.6.0",
-    sparkComponents += "mllib",
+name := "spark-neighbors"
 
-    spShortDescription := "Approximate nearest neighbor search using locality-sensitive hashing",
-	spDescription := """Batch computation of the nearest neighbors for each point in a dataset using:
-	                    | - Hamming distance via bit sampling LSH
-	                    | - Cosine distance via sign-random-projection LSH
-	                    | - Euclidean distance via scalar-random-projection LSH
-	                    | - Jaccard distance via Minhash LSH""".stripMargin
-  )
+organization := "io.github.karlhigley"
+
+version := "0.0.1"
+
+scalaVersion := "2.10.5"
 
 libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-core" % "1.6.0" % "provided",
+  "org.apache.spark" %% "spark-mllib" % "1.6.0" % "provided",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "com.typesafe.akka" %% "akka-actor" % "2.3.4" % "test"
 )
 
-parallelExecution in Test := false
+resolvers ++= Seq(
+  "Akka Repository" at "http://repo.akka.io/releases/",
+  "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
+  "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/"
+)
 
-credentials += Credentials(Path.userHome / ".ivy2" / ".spark-package-credentials")
+parallelExecution in Test := false

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,4 @@
-resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
-
-addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.3")
+resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 


### PR DESCRIPTION
It turns out that sbt-spark-package works with very specific settings for
registering a package to the index, but that those settings do not produce a
resolvable package when using `sbt spPublishLocal` (and also break
`sbt package publishLocal`). It's not clear if Databricks is actively supporting
or maintaining the plugin, so it's probably best to remove from this project.
