### PR TITLE
Simplify candidate generation and persistence

### DIFF
--- a/src/main/scala/io/github/karlhigley/neighbors/ANN.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/ANN.scala
@@ -164,7 +164,7 @@ class ANN private (
     persistenceLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK
   ): ANNModel = {
     var hashFunctions: Array[LSHFunction[_]] = Array()
-    var candidateStrategy: CandidateStrategy = new SimpleCandidateStrategy(persistenceLevel)
+    var candidateStrategy: CandidateStrategy = new SimpleCandidateStrategy
     var distanceMeasure: DistanceMeasure = HammingDistance
     val random = new JavaRandom(randomSeed)
 
@@ -201,7 +201,7 @@ class ANN private (
         distanceMeasure = JaccardDistance
         hashFunctions = (1 to numTables).map(i =>
           MinhashFunction.generate(origDimension, signatureLength, primeModulus, random)).toArray
-        candidateStrategy = new BandingCandidateStrategy(10, persistenceLevel)
+        candidateStrategy = new BandingCandidateStrategy(10)
       }
       case other: Any =>
         throw new IllegalArgumentException(

--- a/src/main/scala/io/github/karlhigley/neighbors/ANNModel.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/ANNModel.scala
@@ -16,8 +16,7 @@ import io.github.karlhigley.neighbors.lsh.{ HashTableEntry, LSHFunction, Signatu
 class ANNModel private[neighbors] (
     private[neighbors] val hashTables: RDD[_ <: HashTableEntry[_]],
     private[neighbors] val candidateStrategy: CandidateStrategy,
-    private[neighbors] val measure: DistanceMeasure,
-    val persistenceLevel: StorageLevel
+    private[neighbors] val measure: DistanceMeasure
 ) extends Serializable {
 
   /**
@@ -67,11 +66,11 @@ object ANNModel {
             hashFunc.hashTableEntry(id, table, vector)
         }
     }
+    hashTables.persist(persistenceLevel)
     new ANNModel(
       hashTables,
       CandidateStrategy,
-      measure,
-      persistenceLevel
+      measure
     )
   }
 }

--- a/src/main/scala/io/github/karlhigley/neighbors/ANNModel.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/ANNModel.scala
@@ -25,7 +25,7 @@ class ANNModel private[neighbors] (
    * the actual distance between candidate pairs.
    */
   def neighbors(quantity: Int): RDD[(Int, Array[(Int, Double)])] = {
-    val candidates = candidateStrategy.identify(hashTables).distinct()
+    val candidates = candidateStrategy.identify(hashTables).repartition(hashTables.getNumPartitions).distinct()
     val neighbors = computeDistances(candidates)
     neighbors.topByKey(quantity)(ANNModel.ordering)
   }

--- a/src/main/scala/io/github/karlhigley/neighbors/candidates/BandingCandidateStrategy.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/candidates/BandingCandidateStrategy.scala
@@ -2,6 +2,7 @@ package io.github.karlhigley.neighbors.candidates
 
 import scala.util.hashing.MurmurHash3
 
+import org.apache.spark.mllib.linalg.SparseVector
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 
@@ -21,7 +22,7 @@ private[neighbors] class BandingCandidateStrategy(
    * Identify candidates by finding a signature match
    * in any band of any hash table.
    */
-  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[(Int, Int)] = {
+  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[((Int, SparseVector), (Int, SparseVector))] = {
     val bandEntries = hashTables.flatMap(entry => {
       val sigElements = entry.signature match {
         case BitSignature(values) => values.toArray
@@ -34,14 +35,14 @@ private[neighbors] class BandingCandidateStrategy(
           // Arrays are mutable and can't be used in RDD keys
           // Use a hash value (i.e. an int) as a substitute
           val bandSigHash = MurmurHash3.arrayHash(bandSig)
-          ((entry.table, band, bandSigHash), entry.id)
+          ((entry.table, band, bandSigHash), (entry.id, entry.point))
         }
       }
     })
 
     bandEntries.persist(persistenceLevel)
     bandEntries.join(bandEntries).flatMap {
-      case (_, (id1, id2)) if (id1 < id2) => Some((id1, id2))
+      case (_, ((id1, point1), (id2, point2))) if (id1 < id2) => Some(((id1, point1), (id2, point2)))
       case _ => None
     }
   }

--- a/src/main/scala/io/github/karlhigley/neighbors/candidates/BandingCandidateStrategy.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/candidates/BandingCandidateStrategy.scala
@@ -14,8 +14,7 @@ import io.github.karlhigley.neighbors.lsh.{ BitSignature, HashTableEntry, IntSig
  * (See Mining Massive Datasets, Ch. 3)
  */
 private[neighbors] class BandingCandidateStrategy(
-    bands: Int,
-    persistenceLevel: StorageLevel
+    bands: Int
 ) extends CandidateStrategy with Serializable {
 
   /**
@@ -40,7 +39,6 @@ private[neighbors] class BandingCandidateStrategy(
       }
     })
 
-    bandEntries.persist(persistenceLevel)
     bandEntries.join(bandEntries).flatMap {
       case (_, ((id1, point1), (id2, point2))) if (id1 < id2) => Some(((id1, point1), (id2, point2)))
       case _ => None

--- a/src/main/scala/io/github/karlhigley/neighbors/candidates/CandidateStrategy.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/candidates/CandidateStrategy.scala
@@ -1,5 +1,6 @@
 package io.github.karlhigley.neighbors.candidates
 
+import org.apache.spark.mllib.linalg.SparseVector
 import org.apache.spark.rdd.RDD
 
 import io.github.karlhigley.neighbors.lsh.HashTableEntry
@@ -12,5 +13,5 @@ import io.github.karlhigley.neighbors.lsh.HashTableEntry
  * banding (for minhash LSH).
  */
 private[neighbors] abstract class CandidateStrategy {
-  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[(Int, Int)]
+  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[((Int, SparseVector), (Int, SparseVector))]
 }

--- a/src/main/scala/io/github/karlhigley/neighbors/candidates/SimpleCandidateStrategy.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/candidates/SimpleCandidateStrategy.scala
@@ -14,9 +14,7 @@ import io.github.karlhigley.neighbors.lsh.{ BitSignature, HashTableEntry, IntSig
  *
  * (See Mining Massive Datasets, Ch. 3)
  */
-private[neighbors] class SimpleCandidateStrategy(
-    persistenceLevel: StorageLevel
-) extends CandidateStrategy with Serializable {
+private[neighbors] class SimpleCandidateStrategy extends CandidateStrategy with Serializable {
 
   /**
    * Identify candidates by finding a signature match
@@ -33,7 +31,6 @@ private[neighbors] class SimpleCandidateStrategy(
       ((entry.table, MurmurHash3.arrayHash(sigElements)), (entry.id, entry.point))
     })
 
-    entries.persist(persistenceLevel)
     entries.join(entries).flatMap {
       case (_, ((id1, point1), (id2, point2))) if (id1 < id2) => Some(((id1, point1), (id2, point2)))
       case _ => None

--- a/src/main/scala/io/github/karlhigley/neighbors/lsh/BitSamplingFunction.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/lsh/BitSamplingFunction.scala
@@ -30,7 +30,7 @@ private[neighbors] class BitSamplingFunction(
    * Build a hash table entry for the supplied vector
    */
   def hashTableEntry(id: Int, table: Int, v: SparseVector): BitHashTableEntry = {
-    BitHashTableEntry(id, table, signature(v))
+    BitHashTableEntry(id, table, signature(v), v)
   }
 }
 

--- a/src/main/scala/io/github/karlhigley/neighbors/lsh/MinhashFunction.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/lsh/MinhashFunction.scala
@@ -36,7 +36,7 @@ private[neighbors] class MinhashFunction(
    * Build a hash table entry for the supplied vector
    */
   def hashTableEntry(id: Int, table: Int, v: SparseVector): IntHashTableEntry = {
-    IntHashTableEntry(id, table, signature(v))
+    IntHashTableEntry(id, table, signature(v), v)
   }
 }
 

--- a/src/main/scala/io/github/karlhigley/neighbors/lsh/ScalarRandomProjectionFunction.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/lsh/ScalarRandomProjectionFunction.scala
@@ -39,7 +39,7 @@ private[neighbors] class ScalarRandomProjectionFunction(
    * Build a hash table entry for the supplied vector
    */
   def hashTableEntry(id: Int, table: Int, v: SparseVector): IntHashTableEntry = {
-    IntHashTableEntry(id, table, signature(v))
+    IntHashTableEntry(id, table, signature(v), v)
   }
 }
 

--- a/src/main/scala/io/github/karlhigley/neighbors/lsh/SignRandomProjectionFunction.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/lsh/SignRandomProjectionFunction.scala
@@ -38,7 +38,7 @@ private[neighbors] class SignRandomProjectionFunction(
    * Build a hash table entry for the supplied vector
    */
   def hashTableEntry(id: Int, table: Int, v: SparseVector): BitHashTableEntry = {
-    BitHashTableEntry(id, table, signature(v))
+    BitHashTableEntry(id, table, signature(v), v)
   }
 }
 

--- a/src/main/scala/io/github/karlhigley/neighbors/lsh/Signature.scala
+++ b/src/main/scala/io/github/karlhigley/neighbors/lsh/Signature.scala
@@ -2,6 +2,8 @@ package io.github.karlhigley.neighbors.lsh
 
 import scala.collection.immutable.BitSet
 
+import org.apache.spark.mllib.linalg.SparseVector
+
 /**
  * This wrapper class allows ANNModel to ignore the
  * type of the hash signatures in its hash tables.
@@ -33,16 +35,19 @@ private[neighbors] sealed abstract class HashTableEntry[+S <: Signature[_]] {
   val id: Int
   val table: Int
   val signature: S
+  val point: SparseVector
 }
 
 private[neighbors] final case class BitHashTableEntry(
   id: Int,
   table: Int,
-  signature: BitSignature
+  signature: BitSignature,
+  point: SparseVector
 ) extends HashTableEntry[BitSignature]
 
 private[neighbors] final case class IntHashTableEntry(
   id: Int,
   table: Int,
-  signature: IntSignature
+  signature: IntSignature,
+  point: SparseVector
 ) extends HashTableEntry[IntSignature]


### PR DESCRIPTION
This simplifies ANNModel and related classes by:
- Including the original points in the hash tables (instead of joining them later)
- Persisting the hash tables instead of other intermediate RDDs
- Repartitioning candidate pairs to avoid partition skew

For further details, see the individual commit messages.
