### PR TITLE
Use `cogroup` instead of `join` to build candidate pairs

### DIFF
--- a/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/BandingCandidateStrategy.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/BandingCandidateStrategy.scala
@@ -21,7 +21,7 @@ private[neighbors] class BandingCandidateStrategy(
    * Identify candidates by finding a signature match
    * in any band of any hash table.
    */
-  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[((Int, SparseVector), (Int, SparseVector))] = {
+  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[CandidateGroup] = {
     val bandEntries = hashTables.flatMap(entry => {
       val sigElements = entry.signature match {
         case BitSignature(values) => values.toArray
@@ -39,9 +39,6 @@ private[neighbors] class BandingCandidateStrategy(
       }
     })
 
-    bandEntries.join(bandEntries).flatMap {
-      case (_, ((id1, point1), (id2, point2))) if (id1 < id2) => Some(((id1, point1), (id2, point2)))
-      case _ => None
-    }
+    bandEntries.cogroup(bandEntries).map(_._2)
   }
 }

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/CandidateStrategy.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/CandidateStrategy.scala
@@ -13,5 +13,8 @@ import com.github.karlhigley.spark.neighbors.lsh.HashTableEntry
  * banding (for minhash LSH).
  */
 private[neighbors] abstract class CandidateStrategy {
-  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[((Int, SparseVector), (Int, SparseVector))]
+  type Point = (Int, SparseVector)
+  type CandidateGroup = (Iterable[Point], Iterable[Point])
+
+  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[CandidateGroup]
 }

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/SimpleCandidateStrategy.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/SimpleCandidateStrategy.scala
@@ -20,7 +20,7 @@ private[neighbors] class SimpleCandidateStrategy extends CandidateStrategy with 
    * Identify candidates by finding a signature match
    * in any hash table.
    */
-  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[((Int, SparseVector), (Int, SparseVector))] = {
+  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[CandidateGroup] = {
     val entries = hashTables.map(entry => {
       val sigElements = entry.signature match {
         case BitSignature(values) => values.toArray
@@ -31,9 +31,6 @@ private[neighbors] class SimpleCandidateStrategy extends CandidateStrategy with 
       ((entry.table, MurmurHash3.arrayHash(sigElements)), (entry.id, entry.point))
     })
 
-    entries.join(entries).flatMap {
-      case (_, ((id1, point1), (id2, point2))) if (id1 < id2) => Some(((id1, point1), (id2, point2)))
-      case _ => None
-    }
+    entries.cogroup(entries).map(_._2)
   }
 }


### PR DESCRIPTION
Using `join` on the hash tables to build the list of candidate pairs results in
many, many copies of the point vectors (one for each candidate neighbor). The
copies take up a lot of memory, and avoiding materializing all of the candidate
pairs would save a lot of memory.

An RDD `join` consists of a `cogroup` followed by a `flatMap`. The output of
`cogroup` is `(K, Iterable[V], Iterable[W])`, and when an RDD is cogrouped with
itself, the output will contain only two copies of each vector. That would be a
big improvement on a `join`, if the output of a `cogroup` can be used directly.

In order to do that, this change combines the distance computation with the
general structure of the `flatMap` used in a `join`. This avoids materializing
vector pairs and outputs `((id1, id2), distance)` records, which are much
smaller.
