### PR TITLE
Fix existential type inference in ANNModel companion object

### DIFF
--- a/src/main/scala/com/github/karlhigley/spark/neighbors/ANNModel.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/ANNModel.scala
@@ -70,7 +70,7 @@ object ANNModel {
     persistenceLevel: StorageLevel
   ): ANNModel = {
 
-    val indHashFunctions = hashFunctions.zipWithIndex
+    val indHashFunctions: Array[(_ <: LSHFunction[_], Int)] = hashFunctions.zipWithIndex
     val hashTables: RDD[_ <: HashTableEntry[_]] = points.flatMap {
       case (id, vector) =>
         indHashFunctions.map {


### PR DESCRIPTION
It's a minor issue, but specifying the type explicitly make a Scala compiler
warning about existential type inference go away.
