### PR TITLE
Prepare the build config for 0.1.0 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,3 +31,45 @@ libraryDependencies ++= Seq(
 spIgnoreProvided := true
 
 parallelExecution in Test := false
+
+publishArtifact in Test := false
+
+publishMavenStyle := true
+
+spAppendScalaVersion := true
+
+spIncludeMaven := true
+
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (version.value.endsWith("SNAPSHOT"))
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+}
+
+pomExtra := (
+  <description>Spark-based approximate nearest neighbor search using locality-sensitive hashing</description>
+  <url>https://github.com/karlhigley/spark-neighbors</url>
+  <licenses>
+    <license>
+      <name>The MIT License (MIT)</name>
+	  <url>http://opensource.org/licenses/MIT</url>
+	  <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <url>git@github.com:karlhigley/spark-neighbors.git</url>
+    <connection>scm:git:git@github.com:karlhigley/spark-neighbors.git</connection>
+  </scm>
+  <developers>
+    <developer>
+      <id>karlhigley</id>
+      <name>Karl Higley</name>
+      <url>https://github.com/karlhigley</url>
+    </developer>
+  </developers>)
+
+pomIncludeRepository := { _ => false }
+
+useGpg := true

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "spark-neighbors"
 
 organization := "com.github.karlhigley"
 
-version := "0.0.1"
+version := "0.1.0"
 
 scalaVersion := "2.10.5"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "spark-neighbors"
 
-organization := "io.github.karlhigley"
+organization := "com.github.karlhigley"
 
 version := "0.0.1"
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,17 +6,28 @@ version := "0.0.1"
 
 scalaVersion := "2.10.5"
 
+spName := "karlhigley/spark-neighbors"
+
+sparkVersion := "1.6.0"
+
+sparkComponents := Seq("core", "mllib")
+
+val testSparkVersion = settingKey[String]("The version of Spark to test against.")
+
+testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.value)
+
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core" % "1.6.0" % "provided",
-  "org.apache.spark" %% "spark-mllib" % "1.6.0" % "provided",
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "com.typesafe.akka" %% "akka-actor" % "2.3.4" % "test"
+  "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )
 
-resolvers ++= Seq(
-  "Akka Repository" at "http://repo.akka.io/releases/",
-  "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
-  "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/"
+libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test" force(),
+  "org.apache.spark" %% "spark-mllib" % testSparkVersion.value % "test" force(),
+  "org.scala-lang" % "scala-library" % scalaVersion.value % "compile"
 )
+
+// This is necessary because of how we explicitly specify Spark dependencies
+// for tests rather than using the sbt-spark-package plugin to provide them.
+spIgnoreProvided := true
 
 parallelExecution in Test := false

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
-resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
+
+addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.3")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 


### PR DESCRIPTION
With four distance measures supported, support for multiple hash tables, and
memory usage issues ironed out, this will be the first release. There's a lot
left to do, of course, but this passes the bar for releasing. Ship it!
