### PR TITLE
Fix number of bands provided to candidate strategy for Jaccard distance

### DIFF
--- a/src/main/scala/com/github/karlhigley/spark/neighbors/ANN.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/ANN.scala
@@ -201,7 +201,7 @@ class ANN private (
         distanceMeasure = JaccardDistance
         hashFunctions = (1 to numTables).map(i =>
           MinhashFunction.generate(origDimension, signatureLength, primeModulus, random)).toArray
-        candidateStrategy = new BandingCandidateStrategy(10)
+        candidateStrategy = new BandingCandidateStrategy(numBands)
       }
       case other: Any =>
         throw new IllegalArgumentException(


### PR DESCRIPTION
The builder param wasn't actually being used. Oops! Resolves #25.
