### PR TITLE
Improve the performance of candidate pair generation

### DIFF
--- a/src/main/scala/com/github/karlhigley/spark/neighbors/ANNModel.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/ANNModel.scala
@@ -20,7 +20,7 @@ class ANNModel private[neighbors] (
 ) extends Serializable {
 
   type Point = (Int, SparseVector)
-  type CandidateGroup = (Iterable[Point], Iterable[Point])
+  type CandidateGroup = Iterable[Point]
 
   /**
    * Identify pairs of nearest neighbors by applying a
@@ -40,10 +40,10 @@ class ANNModel private[neighbors] (
   private def computeDistances(candidates: RDD[CandidateGroup]): RDD[(Int, (Int, Double))] = {
     candidates
       .flatMap {
-        case (listA, listB) => {
+        case candidates => {
           for (
-            (id1, vector1) <- listA.iterator;
-            (id2, vector2) <- listB.iterator;
+            (id1, vector1) <- candidates.iterator;
+            (id2, vector2) <- candidates.iterator;
             if id1 < id2
           ) yield ((id1, id2), measure.compute(vector1, vector2))
         }

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/ANNModel.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/ANNModel.scala
@@ -28,7 +28,7 @@ class ANNModel private[neighbors] (
    * the actual distance between candidate pairs.
    */
   def neighbors(quantity: Int): RDD[(Int, Array[(Int, Double)])] = {
-    val candidates = candidateStrategy.identify(hashTables).repartition(hashTables.getNumPartitions)
+    val candidates = candidateStrategy.identify(hashTables).groupByKey(hashTables.getNumPartitions).values
     val neighbors = computeDistances(candidates)
     neighbors.topByKey(quantity)(ANNModel.ordering)
   }

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/BandingCandidateStrategy.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/BandingCandidateStrategy.scala
@@ -21,7 +21,7 @@ private[neighbors] class BandingCandidateStrategy(
    * Identify candidates by finding a signature match
    * in any band of any hash table.
    */
-  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[CandidateGroup] = {
+  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[(Product, Point)] = {
     val bandEntries = hashTables.flatMap(entry => {
       val sigElements = entry.signature match {
         case BitSignature(values) => values.toArray
@@ -34,11 +34,11 @@ private[neighbors] class BandingCandidateStrategy(
           // Arrays are mutable and can't be used in RDD keys
           // Use a hash value (i.e. an int) as a substitute
           val bandSigHash = MurmurHash3.arrayHash(bandSig)
-          ((entry.table, band, bandSigHash), (entry.id, entry.point))
+          ((entry.table, band, bandSigHash).asInstanceOf[Product], (entry.id, entry.point))
         }
       }
     })
 
-    bandEntries.groupByKey().map(_._2)
+    bandEntries
   }
 }

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/BandingCandidateStrategy.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/BandingCandidateStrategy.scala
@@ -39,6 +39,6 @@ private[neighbors] class BandingCandidateStrategy(
       }
     })
 
-    bandEntries.cogroup(bandEntries).map(_._2)
+    bandEntries.groupByKey().map(_._2)
   }
 }

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/CandidateStrategy.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/CandidateStrategy.scala
@@ -14,7 +14,6 @@ import com.github.karlhigley.spark.neighbors.lsh.HashTableEntry
  */
 private[neighbors] abstract class CandidateStrategy {
   type Point = (Int, SparseVector)
-  type CandidateGroup = Iterable[Point]
 
-  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[CandidateGroup]
+  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[(Product, Point)]
 }

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/CandidateStrategy.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/CandidateStrategy.scala
@@ -14,7 +14,7 @@ import com.github.karlhigley.spark.neighbors.lsh.HashTableEntry
  */
 private[neighbors] abstract class CandidateStrategy {
   type Point = (Int, SparseVector)
-  type CandidateGroup = (Iterable[Point], Iterable[Point])
+  type CandidateGroup = Iterable[Point]
 
   def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[CandidateGroup]
 }

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/SimpleCandidateStrategy.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/SimpleCandidateStrategy.scala
@@ -31,6 +31,6 @@ private[neighbors] class SimpleCandidateStrategy extends CandidateStrategy with 
       ((entry.table, MurmurHash3.arrayHash(sigElements)), (entry.id, entry.point))
     })
 
-    entries.cogroup(entries).map(_._2)
+    entries.groupByKey().map(_._2)
   }
 }

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/SimpleCandidateStrategy.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/SimpleCandidateStrategy.scala
@@ -20,7 +20,7 @@ private[neighbors] class SimpleCandidateStrategy extends CandidateStrategy with 
    * Identify candidates by finding a signature match
    * in any hash table.
    */
-  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[CandidateGroup] = {
+  def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[(Product, Point)] = {
     val entries = hashTables.map(entry => {
       val sigElements = entry.signature match {
         case BitSignature(values) => values.toArray
@@ -28,9 +28,9 @@ private[neighbors] class SimpleCandidateStrategy extends CandidateStrategy with 
       }
       // Arrays are mutable and can't be used in RDD keys
       // Use a hash value (i.e. an int) as a substitute
-      ((entry.table, MurmurHash3.arrayHash(sigElements)), (entry.id, entry.point))
+      ((entry.table, MurmurHash3.arrayHash(sigElements)).asInstanceOf[Product], (entry.id, entry.point))
     })
 
-    entries.groupByKey().map(_._2)
+    entries
   }
 }


### PR DESCRIPTION
There are two related changes here:
- Use `groupByKey` instead of `cogroup` to reduce the memory usage of candidate generation
- Move grouping outside of the candidate strategies so that it can be combined with repartitioning in order to reduce the number of shuffles
