### PR TITLE
Move conversion of signature elements to arrays into `HashTableEntry` classes

### DIFF
--- a/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/BandingCandidateStrategy.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/BandingCandidateStrategy.scala
@@ -23,18 +23,14 @@ private[neighbors] class BandingCandidateStrategy(
    */
   def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[(Product, Point)] = {
     val bandEntries = hashTables.flatMap(entry => {
-      val sigElements = entry.signature match {
-        case BitSignature(values) => values.toArray
-        case IntSignature(values) => values
-      }
-
-      val banded = sigElements.grouped(bands).zipWithIndex
+      val banded = entry.sigElements.grouped(bands).zipWithIndex
       banded.map {
         case (bandSig, band) => {
           // Arrays are mutable and can't be used in RDD keys
           // Use a hash value (i.e. an int) as a substitute
           val bandSigHash = MurmurHash3.arrayHash(bandSig)
-          ((entry.table, band, bandSigHash).asInstanceOf[Product], (entry.id, entry.point))
+          val key = (entry.table, band, bandSigHash).asInstanceOf[Product]
+          (key, (entry.id, entry.point))
         }
       }
     })

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/SimpleCandidateStrategy.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/candidates/SimpleCandidateStrategy.scala
@@ -22,13 +22,10 @@ private[neighbors] class SimpleCandidateStrategy extends CandidateStrategy with 
    */
   def identify(hashTables: RDD[_ <: HashTableEntry[_]]): RDD[(Product, Point)] = {
     val entries = hashTables.map(entry => {
-      val sigElements = entry.signature match {
-        case BitSignature(values) => values.toArray
-        case IntSignature(values) => values
-      }
       // Arrays are mutable and can't be used in RDD keys
       // Use a hash value (i.e. an int) as a substitute
-      ((entry.table, MurmurHash3.arrayHash(sigElements)).asInstanceOf[Product], (entry.id, entry.point))
+      val key = (entry.table, MurmurHash3.arrayHash(entry.sigElements)).asInstanceOf[Product]
+      (key, (entry.id, entry.point))
     })
 
     entries

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/lsh/Signature.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/lsh/Signature.scala
@@ -9,21 +9,21 @@ import org.apache.spark.mllib.linalg.SparseVector
  * type of the hash signatures in its hash tables.
  */
 private[neighbors] sealed trait Signature[+T] extends Any {
-  val values: T
+  val elements: T
 }
 
 /**
  * Signature type for sign-random-projection LSH
  */
 private[neighbors] final case class BitSignature(
-  values: BitSet
+  elements: BitSet
 ) extends AnyVal with Signature[BitSet]
 
 /**
  * Signature type for scalar-random-projection LSH
  */
 private[neighbors] final case class IntSignature(
-  values: Array[Int]
+  elements: Array[Int]
 ) extends AnyVal with Signature[Array[Int]]
 
 /**
@@ -36,18 +36,28 @@ private[neighbors] sealed abstract class HashTableEntry[+S <: Signature[_]] {
   val table: Int
   val signature: S
   val point: SparseVector
+
+  def sigElements: Array[Int]
 }
 
 private[neighbors] final case class BitHashTableEntry(
-  id: Int,
-  table: Int,
-  signature: BitSignature,
-  point: SparseVector
-) extends HashTableEntry[BitSignature]
+    id: Int,
+    table: Int,
+    signature: BitSignature,
+    point: SparseVector
+) extends HashTableEntry[BitSignature] {
+  def sigElements: Array[Int] = {
+    signature.elements.toArray
+  }
+}
 
 private[neighbors] final case class IntHashTableEntry(
-  id: Int,
-  table: Int,
-  signature: IntSignature,
-  point: SparseVector
-) extends HashTableEntry[IntSignature]
+    id: Int,
+    table: Int,
+    signature: IntSignature,
+    point: SparseVector
+) extends HashTableEntry[IntSignature] {
+  def sigElements: Array[Int] = {
+    signature.elements
+  }
+}


### PR DESCRIPTION
This avoids having to pattern match on signature types in the candidate
strategies. There are also some minor readability edits to the strategies and
signatures types along the way.
