### PR TITLE
Refactor test helpers and quiet down test log messages

### DIFF
--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Set Spark log level
+log4j.logger.org.apache.spark=WARN
+
+# Silence akka remoting
+log4j.logger.Remoting=WARN
+
+# Ignore messages below warning level from Jetty
+log4j.logger.org.eclipse.jetty=WARN

--- a/src/test/scala/com/github/karlhigley/spark/neighbors/ANNSuite.scala
+++ b/src/test/scala/com/github/karlhigley/spark/neighbors/ANNSuite.scala
@@ -1,8 +1,5 @@
 package com.github.karlhigley.spark.neighbors
 
-import scala.util.Random
-
-import org.apache.spark.mllib.linalg.SparseVector
 import org.scalatest.FunSuite
 
 import com.github.karlhigley.spark.neighbors.lsh.HashTableEntry
@@ -14,7 +11,7 @@ class ANNSuite extends FunSuite with TestSparkContext {
   val dimensions = 100
   val density = 0.5
 
-  val localPoints = generateRandomPoints(numPoints, dimensions, density)
+  val localPoints = TestHelpers.generateRandomPoints(numPoints, dimensions, density)
 
   test("compute hamming nearest neighbors as a batch") {
     val points = sc.parallelize(localPoints.zipWithIndex.map(_.swap))
@@ -137,41 +134,5 @@ object ANNSuite {
         }
       }
     }
-  }
-
-  def generateRandomPoints(quantity: Int, dimensions: Int, density: Double) = {
-    val numElements = math.floor(dimensions * density).toInt
-    val points = new Array[SparseVector](quantity)
-    var i = 0
-    while (i < quantity) {
-      val indices = generateIndices(numElements, dimensions)
-      val values = generateValues(numElements)
-      points(i) = new SparseVector(dimensions, indices, values)
-      i += 1
-    }
-    points
-  }
-
-  def generateIndices(quantity: Int, dimensions: Int) = {
-    val indices = new Array[Int](quantity)
-    var i = 0
-    while (i < quantity) {
-      val possible = Random.nextInt(dimensions)
-      if (!indices.contains(possible)) {
-        indices(i) = possible
-        i += 1
-      }
-    }
-    indices
-  }
-
-  def generateValues(quantity: Int) = {
-    val values = new Array[Double](quantity)
-    var i = 0
-    while (i < quantity) {
-      values(i) = Random.nextGaussian()
-      i += 1
-    }
-    values
   }
 }

--- a/src/test/scala/com/github/karlhigley/spark/neighbors/TestHelpers.scala
+++ b/src/test/scala/com/github/karlhigley/spark/neighbors/TestHelpers.scala
@@ -1,0 +1,43 @@
+package com.github.karlhigley.spark.neighbors
+
+import scala.util.Random
+
+import org.apache.spark.mllib.linalg.SparseVector
+
+object TestHelpers {
+  def generateRandomPoints(quantity: Int, dimensions: Int, density: Double) = {
+    val numElements = math.floor(dimensions * density).toInt
+    val points = new Array[SparseVector](quantity)
+    var i = 0
+    while (i < quantity) {
+      val indices = generateIndices(numElements, dimensions)
+      val values = generateValues(numElements)
+      points(i) = new SparseVector(dimensions, indices, values)
+      i += 1
+    }
+    points
+  }
+
+  def generateIndices(quantity: Int, dimensions: Int) = {
+    val indices = new Array[Int](quantity)
+    var i = 0
+    while (i < quantity) {
+      val possible = Random.nextInt(dimensions)
+      if (!indices.contains(possible)) {
+        indices(i) = possible
+        i += 1
+      }
+    }
+    indices
+  }
+
+  def generateValues(quantity: Int) = {
+    val values = new Array[Double](quantity)
+    var i = 0
+    while (i < quantity) {
+      values(i) = Random.nextGaussian()
+      i += 1
+    }
+    values
+  }
+}


### PR DESCRIPTION
- Extracts test helpers to a separate object for easier reuse across files
- Quiet down the Spark logs while running tests by setting log levels to WARN
