### PR TITLE
Add average selectivity computation to ANNModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,6 @@ Minhash:
 Survey papers:
 - Loic Pauleve, Herve Jegou, Laurent Amsaleg. "[Locality sensitive hashing: a comparison of hash function types and querying mechanisms.](https://hal.inria.fr/file/index/docid/567191/filename/paper.pdf)" Pattern Recognition Letters, 2010.
 - Jingdong Wang, Heng Tao Shen, Jingkuan Song, and Jianqiu Ji. "[Hashing for similarity search: A survey.](http://arxiv.org/pdf/1408.2927.pdf)" CoRR, abs/1408.2927, 2014.
+
+Performance evaluation and tuning:
+- Wei Dong, Zhe Wang, William Josephson, Moses Charikar, and Kai Li. "[Modeling LSH for performance tuning](http://www.cs.princeton.edu/cass/papers/cikm08.pdf)" CIKM, 2008.

--- a/src/test/scala/com/github/karlhigley/spark/neighbors/ANNModelSuite.scala
+++ b/src/test/scala/com/github/karlhigley/spark/neighbors/ANNModelSuite.scala
@@ -1,0 +1,61 @@
+package com.github.karlhigley.spark.neighbors
+
+import org.scalatest.FunSuite
+
+import com.github.karlhigley.spark.neighbors.lsh.HashTableEntry
+
+class ANNModelSuite extends FunSuite with TestSparkContext {
+  val numPoints = 1000
+  val dimensions = 100
+  val density = 0.5
+
+  val localPoints = TestHelpers.generateRandomPoints(numPoints, dimensions, density)
+
+  test("average selectivity is between zero and one") {
+    val points = sc.parallelize(localPoints.zipWithIndex.map(_.swap))
+
+    val ann =
+      new ANN(dimensions, "cosine")
+        .setTables(1)
+        .setSignatureLength(16)
+
+    val model = ann.train(points)
+    val selectivity = model.avgSelectivity()
+
+    assert(selectivity > 0.0)
+    assert(selectivity < 1.0)
+  }
+
+  test("average selectivity increases with more tables") {
+    val points = sc.parallelize(localPoints.zipWithIndex.map(_.swap))
+
+    val ann =
+      new ANN(dimensions, "cosine")
+        .setTables(1)
+        .setSignatureLength(16)
+
+    val model1 = ann.train(points)
+
+    ann.setTables(2)
+    val model2 = ann.train(points)
+
+    assert(model1.avgSelectivity() < model2.avgSelectivity())
+  }
+
+  test("average selectivity decreases with signature length") {
+    val points = sc.parallelize(localPoints.zipWithIndex.map(_.swap))
+
+    val ann =
+      new ANN(dimensions, "cosine")
+        .setTables(1)
+        .setSignatureLength(4)
+
+    val model4 = ann.train(points)
+
+    ann.setSignatureLength(8)
+    val model8 = ann.train(points)
+
+    assert(model4.avgSelectivity() > model8.avgSelectivity())
+  }
+
+}


### PR DESCRIPTION
Selectivity measures the fraction of the points that are considered as
candidate neighbors for a particular point. Averaging selectivity over
all points provides an indicator of how many distance computations are
performed after hashing.
