### PR TITLE
Add support for Manhattan distance via scalar random projection LSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ val neighbors = model.neighbors(10)
 
 #### Distance Measures and Parameters
 
-The supported distance measures are "hamming", "cosine", "euclidean", and "jaccard". All distance measures allow the number of hash tables and the length of the computed hash signatures to be configured as above. The hashing schemes for Euclidean and Jaccard distances have some additional configurable parameters:
+The supported distance measures are "hamming", "cosine", "euclidean", "manhattan", and "jaccard". All distance measures allow the number of hash tables and the length of the computed hash signatures to be configured as above. The hashing schemes for Euclidean, Manhattan, and Jaccard distances have some additional configurable parameters:
 
-##### Euclidean Distance
+##### Euclidean and Manhattan Distances
 
 This hash function depends on a bucket or quantization width. Higher widths lead to signatures that are more similar:
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ val testSparkVersion = settingKey[String]("The version of Spark to test against.
 testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.value)
 
 libraryDependencies ++= Seq(
+  "org.scalanlp" %% "breeze" % "0.12",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )
 

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/linalg/DistanceMeasure.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/linalg/DistanceMeasure.scala
@@ -1,5 +1,6 @@
 package com.github.karlhigley.spark.neighbors.linalg
 
+import breeze.linalg.norm
 import org.apache.spark.mllib.linalg.{ SparseVector, Vectors }
 
 import org.apache.spark.mllib.linalg.LinalgShim
@@ -44,6 +45,19 @@ private[neighbors] final object EuclideanDistance extends DistanceMeasure {
    */
   def compute(v1: SparseVector, v2: SparseVector): Double = {
     Vectors.sqdist(v1, v2)
+  }
+}
+
+private[neighbors] final object ManhattanDistance extends DistanceMeasure {
+
+  /**
+   * Compute Manhattan distance between vectors using
+   * Breeze vector operations
+   */
+  def compute(v1: SparseVector, v2: SparseVector): Double = {
+    val b1 = LinalgShim.toBreeze(v1)
+    val b2 = LinalgShim.toBreeze(v2)
+    norm(b1 - b2, 1.0)
   }
 }
 

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/linalg/RandomProjection.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/linalg/RandomProjection.scala
@@ -2,6 +2,7 @@ package com.github.karlhigley.spark.neighbors.linalg
 
 import java.util.Random
 
+import breeze.stats.distributions.CauchyDistribution
 import org.apache.spark.mllib.linalg.{ DenseMatrix, Matrices }
 import org.apache.spark.mllib.linalg.{ DenseVector, Vector }
 
@@ -27,8 +28,22 @@ private[neighbors] object RandomProjection {
    * Generate a random projection based on the input and output
    * dimensions
    */
-  def generate(originalDim: Int, projectedDim: Int, random: Random): RandomProjection = {
+  def generateGaussian(originalDim: Int, projectedDim: Int, random: Random): RandomProjection = {
     val localMatrix = DenseMatrix.randn(projectedDim, originalDim, random)
+    new RandomProjection(localMatrix)
+  }
+
+  def generateCauchy(originalDim: Int, projectedDim: Int, random: Random): RandomProjection = {
+    def randc(numRows: Int, numCols: Int): DenseMatrix = {
+      require(
+        numRows.toLong * numCols <= Int.MaxValue,
+        s"$numRows x $numCols dense matrix is too large to allocate"
+      )
+      val cauchyDistribution = new CauchyDistribution(0, 1)
+      new DenseMatrix(numRows, numCols, cauchyDistribution.drawMany(numRows * numCols))
+    }
+
+    val localMatrix = randc(projectedDim, originalDim)
     new RandomProjection(localMatrix)
   }
 }

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/lsh/ScalarRandomProjectionFunction.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/lsh/ScalarRandomProjectionFunction.scala
@@ -45,22 +45,55 @@ private[neighbors] class ScalarRandomProjectionFunction(
 
 private[neighbors] object ScalarRandomProjectionFunction {
   /**
-   * Build a random hash function, given the vector dimension,
-   * signature length, and bucket width.
+   * Build a random hash function for Manhattan distance
+   * given the vector dimension, signature length, and bucket width.
    *
    * @param originalDim dimensionality of the vectors to be hashed
    * @param signatureLength the number of integers in each hash signature
    * @param bucketWidth the width to use when truncating hash values to integers
    * @return randomly selected hash function from scalar RP family
    */
-  def generate(
+  def generateL1(
     originalDim: Int,
     signatureLength: Int,
     bucketWidth: Double,
     random: Random = new Random
   ): ScalarRandomProjectionFunction = {
+    val generator = RandomProjection.generateCauchy _
+    generate(originalDim, signatureLength, bucketWidth, generator, random)
+  }
 
-    val projection = RandomProjection.generate(originalDim, signatureLength, random)
+  /**
+   * Build a random hash function for Euclidean distance
+   * given the vector dimension, signature length, and bucket width.
+   *
+   * @param originalDim dimensionality of the vectors to be hashed
+   * @param signatureLength the number of integers in each hash signature
+   * @param bucketWidth the width to use when truncating hash values to integers
+   * @return randomly selected hash function from scalar RP family
+   */
+  def generateL2(
+    originalDim: Int,
+    signatureLength: Int,
+    bucketWidth: Double,
+    random: Random = new Random
+  ): ScalarRandomProjectionFunction = {
+    val generator = RandomProjection.generateGaussian _
+    generate(originalDim, signatureLength, bucketWidth, generator, random)
+  }
+
+  /**
+   * Build a random hash function, given the vector dimension,
+   * signature length, bucket width, and a projection generator.
+   */
+  private def generate(
+    originalDim: Int,
+    signatureLength: Int,
+    bucketWidth: Double,
+    generator: (Int, Int, Random) => RandomProjection,
+    random: Random = new Random
+  ): ScalarRandomProjectionFunction = {
+    val projection = generator(originalDim, signatureLength, random)
     val offsets = generateOffsets(signatureLength, bucketWidth, random)
     new ScalarRandomProjectionFunction(projection, offsets, bucketWidth)
   }

--- a/src/main/scala/com/github/karlhigley/spark/neighbors/lsh/SignRandomProjectionFunction.scala
+++ b/src/main/scala/com/github/karlhigley/spark/neighbors/lsh/SignRandomProjectionFunction.scala
@@ -57,7 +57,7 @@ private[neighbors] object SignRandomProjectionFunction {
     random: Random = new Random
   ): SignRandomProjectionFunction = {
 
-    val projection = RandomProjection.generate(originalDim, signatureLength, random)
+    val projection = RandomProjection.generateGaussian(originalDim, signatureLength, random)
     new SignRandomProjectionFunction(projection, signatureLength)
   }
 }

--- a/src/main/scala/org/apache/spark/mllib/linalg/LinalgShim.scala
+++ b/src/main/scala/org/apache/spark/mllib/linalg/LinalgShim.scala
@@ -1,5 +1,7 @@
 package org.apache.spark.mllib.linalg
 
+import breeze.linalg.{ SparseVector => BSV, Vector => BV }
+
 /**
  * This shim reaches into Spark's private linear algebra
  * code, in order to take advantage of optimized dot products.
@@ -20,5 +22,13 @@ object LinalgShim {
    */
   def dot(x: Vector, y: Vector): Double = {
     BLAS.dot(x, y)
+  }
+
+  /**
+   * Convert a Spark vector to a Breeze vector to access
+   * vector operations that Spark doesn't provide.
+   */
+  def toBreeze(x: Vector): BV[Double] = {
+    x.toBreeze
   }
 }

--- a/src/test/scala/com/github/karlhigley/spark/neighbors/ANNSuite.scala
+++ b/src/test/scala/com/github/karlhigley/spark/neighbors/ANNSuite.scala
@@ -65,6 +65,24 @@ class ANNSuite extends FunSuite with TestSparkContext {
     runAssertions(localHashTables, localNeighbors)
   }
 
+  test("compute manhattan nearest neighbors as a batch") {
+    val points = sc.parallelize(localPoints.zipWithIndex.map(_.swap))
+
+    val ann =
+      new ANN(dimensions, "manhattan")
+        .setTables(1)
+        .setSignatureLength(4)
+        .setBucketWidth(25)
+
+    val model = ann.train(points)
+    val neighbors = model.neighbors(10)
+
+    val localHashTables = model.hashTables.collect()
+    val localNeighbors = neighbors.collect()
+
+    runAssertions(localHashTables, localNeighbors)
+  }
+
   test("compute jaccard nearest neighbors as a batch") {
     val points = sc.parallelize(localPoints.zipWithIndex.map(_.swap))
 


### PR DESCRIPTION
This extends the scalar random projection LSH method already used for
Euclidean distance to also work for Manhattan distance (as explained in
"Locality-sensitive hashing scheme based on p-stable distributions").

Since MLlib's vector and matrix operations are fairly limited, this
drops down to Breeze in order to generate projection matrices from
the standard Cauchy distribution and compute Manhattan distance between
vectors.
