### PR TITLE
Add the ability to find the neighbors of a set of query points

### DIFF
--- a/src/test/scala/com/github/karlhigley/spark/neighbors/ANNSuite.scala
+++ b/src/test/scala/com/github/karlhigley/spark/neighbors/ANNSuite.scala
@@ -126,6 +126,22 @@ class ANNSuite extends FunSuite with TestSparkContext {
       }
     }
   }
+
+  test("find neighbors for a set of query points") {
+    val points = sc.parallelize(localPoints.zipWithIndex.map(_.swap))
+
+    val localTestPoints = TestHelpers.generateRandomPoints(100, dimensions, density)
+    val testPoints = sc.parallelize(localTestPoints.zipWithIndex.map(_.swap))
+
+    val ann =
+      new ANN(dimensions, "hamming")
+        .setTables(1)
+        .setSignatureLength(16)
+
+    val model = ann.train(points)
+    val neighbors = model.neighbors(testPoints, 10)
+    val neighborIds = neighbors.map(_._1)
+  }
 }
 
 object ANNSuite {


### PR DESCRIPTION
A new version of the `ANNModel.neighbors()` method finds neighbors from
among the model's points for each of a set of query points. This enables
queries across two sets of points, for use cases like finding the
items nearest to user preference vectors in recommender systems.
