### PR TITLE
Remove text about querying models as a "nice to add" from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ val annModel =
 
 Would be nice to add:
 
-- Queries against pre-trained models. The existing code only supports computing the neighbors of all points as a batch, but it would be great to be able to quickly get neighbors for a single point or a small set of points (e.g. for streaming applications).
-
 - Dense vector support. Currently, only sparse vectors are supported, since high dimensional data (e.g. TFIDF vectors) are likely to be sparse. It could be handy to also support dense vectors, but that will likely require optimized variants of some code paths for both dense and sparse vectors.
 
 - Distributed random projections. Currently, projection matrices must fit in worker memory. There's an open JIRA ticket to add distributed random projection to Spark's MLlib ([SPARK-7334](https://issues.apache.org/jira/browse/SPARK-7334)); in the mean time, they could also be implemented here as an alternate subclass of RandomProjection. I've previously [implemented](https://github.com/karlhigley/lexrank-summarizer/blob/master/src/main/scala/io/github/karlhigley/lexrank/SignRandomProjectionLSH.scala) arbitrarily large projection matrices via the [pooling trick](http://personal.denison.edu/~lalla/papers/online-lsh.pdf), which could also be included as an option in the future.


### PR DESCRIPTION
I forgot to remove this when I added the feature.
